### PR TITLE
Add Environment configuration for the lldb-dap process and Add zig breakpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lldb-dap",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lldb-dap",
-      "version": "0.2.0",
+      "version": "0.2.4",
       "license": "Apache 2.0 License with LLVM exceptions",
       "devDependencies": {
         "@types/node": "^18.11.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lldb-dap",
   "displayName": "LLDB DAP",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "llvm-vs-code-extensions",
   "homepage": "https://lldb.llvm.org",
   "description": "LLDB debugging from VSCode",
@@ -73,6 +73,15 @@
           "scope": "resource",
           "type": "string",
           "description": "The path to the lldb-dap binary."
+        },
+        "lldb-dap.environment": {
+          "scope": "resource",
+          "type": "object",
+          "default": {},
+          "description": "The environment of the lldb-dap process.",
+          "additionalProperties": {
+             "type": "string"
+          }
         }
       }
     },
@@ -118,6 +127,9 @@
       },
       {
         "language": "rust"
+      },
+	  {
+        "language": "zig"
       },
       {
         "language": "swift"

--- a/src-ts/extension.ts
+++ b/src-ts/extension.ts
@@ -14,11 +14,14 @@ function createDefaultLLDBDapOptions(): LLDBDapOptions {
       session: vscode.DebugSession,
       packageJSONExecutable: vscode.DebugAdapterExecutable | undefined,
     ): Promise<vscode.DebugAdapterExecutable | undefined> {
-      const path = vscode.workspace
-        .getConfiguration("lldb-dap", session.workspaceFolder)
-        .get<string>("executable-path");
+      const configuration = vscode.workspace.getConfiguration("lldb-dap", session.workspaceFolder);
+      const path = configuration.get<string>("executable-path");
       if (path) {
-        return new vscode.DebugAdapterExecutable(path, []);
+        const environment = configuration.get<{ [key: string]: string }>("environment") || {};
+        const dbgOptions = {
+            env: environment
+        };
+        return new vscode.DebugAdapterExecutable(path, [], dbgOptions);
       }
       return packageJSONExecutable;
     },


### PR DESCRIPTION
Frequently, environment variables such as LLDB_USE_NATIVE_PDB_READER are needed to be able to use lldb-dap in vscode

This PR adds a way to set the environment for the lldb-dap process using configuration.
Also zig is added to the language file types for which setting breakpoints will be enabled.