### PR TITLE
Allow setting breakpoints in objc++ files

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,6 +302,9 @@
         "language": "objective-c"
       },
       {
+        "language": "objective-cpp"
+      },
+      {
         "language": "objectpascal"
       },
       {
@@ -329,6 +332,7 @@
           "fortran-modern",
           "nim",
           "objective-c",
+          "objective-cpp",
           "objectpascal",
           "pascal",
           "rust",


### PR DESCRIPTION
With the released verson of the extension, I have to set breakpoints in objcpp  (*.mm) files via the debug console (`b Myfile.mm:123`) or change the detected file type in VSCode to objc or cpp.  VSCode should allow setting breakpoints in objcpp files with vscode-lldb with this change to the package.json